### PR TITLE
Fix hardcoded paths

### DIFF
--- a/qnvim.pro
+++ b/qnvim.pro
@@ -32,4 +32,4 @@ isEmpty(IDE_BUILD_TREE): IDE_BUILD_TREE = $$(QTC_BUILD)
 include($$IDE_SOURCE_TREE/src/qtcreatorplugin.pri)
 
 INCLUDEPATH += $$NEOVIM_QT_SOURCE_TREE/src
-LIBS += -L$$NEOVIM_BUILD_TREE/lib/ -lneovim-qt -lneovim-qt-gui -l msgpackc
+LIBS += -L$$NEOVIM_QT_BUILD_TREE/lib/ -lneovim-qt -lneovim-qt-gui -l msgpackc

--- a/qnvim.pro
+++ b/qnvim.pro
@@ -31,5 +31,5 @@ isEmpty(IDE_BUILD_TREE): IDE_BUILD_TREE = $$(QTC_BUILD)
 
 include($$IDE_SOURCE_TREE/src/qtcreatorplugin.pri)
 
-INCLUDEPATH += $$NEOVIM_SOURCE_TREE/src
+INCLUDEPATH += $$NEOVIM_QT_SOURCE_TREE/src
 LIBS += -L$$NEOVIM_BUILD_TREE/lib/ -lneovim-qt -lneovim-qt-gui -l msgpackc

--- a/qnvim.pro
+++ b/qnvim.pro
@@ -27,9 +27,9 @@ isEmpty(IDE_BUILD_TREE): IDE_BUILD_TREE = $$(QTC_BUILD)
 ##    "%LOCALAPPDATA%\QtProject\qtcreator" on Windows Vista and later
 ##    "$XDG_DATA_HOME/data/QtProject/qtcreator" or "~/.local/share/data/QtProject/qtcreator" on Linux
 ##    "~/Library/Application Support/QtProject/Qt Creator" on macOS
-USE_USER_DESTDIR = yes
+##USE_USER_DESTDIR = yes
 
 include($$IDE_SOURCE_TREE/src/qtcreatorplugin.pri)
 
-INCLUDEPATH += /home/sassan/Development/neovim-qt/src/
-LIBS += -L/home/sassan/Development/neovim-qt/build/lib/ -lneovim-qt -lneovim-qt-gui -l msgpackc
+INCLUDEPATH += $$NEOVIM_SOURCE_TREE/src
+LIBS += -L$$NEOVIM_BUILD_TREE/lib/ -lneovim-qt -lneovim-qt-gui -l msgpackc


### PR DESCRIPTION
Hi! Thank you for your plugin. I would like to add this package to [AUR](https://aur.archlinux.org) for Arch Linux users, but I see that you have hardcoded paths for Neovim Qt source and build tree. In this PR I changed it to the `NEOVIM_SOURCE_TREE` and `NEOVIM_BUILD_TREE` variables.

I also commented `USE_USER_DESTDIR = yes` by default because set this variable for user is much easier than for build system.