### PR TITLE
Remove cursor blinking

### DIFF
--- a/qnvimplugin.cpp
+++ b/qnvimplugin.cpp
@@ -82,6 +82,7 @@
 #include <QRegularExpression>
 #include <QScrollBar>
 #include <QStandardPaths>
+#include <QStyleHints>
 #include <QTextBlock>
 #include <QTextEdit>
 #include <QThread>
@@ -413,6 +414,15 @@ void QNVimPlugin::triggerCommand(const QByteArray &commandId)
     Core::ActionManager::command(commandId.constData())->action()->trigger();
 }
 
+void QNVimPlugin::saveCursorFlashTime(int cursorFlashTime)
+{
+    mSavedCursorFlashTime = cursorFlashTime;
+
+    disconnect(QApplication::styleHints(), &QStyleHints::cursorFlashTimeChanged, this, &QNVimPlugin::saveCursorFlashTime);
+    QApplication::setCursorFlashTime(-1);
+    connect(QApplication::styleHints(), &QStyleHints::cursorFlashTimeChanged, this, &QNVimPlugin::saveCursorFlashTime);
+}
+
 bool QNVimPlugin::initialize(const QStringList &arguments, QString *errorString)
 {
     Q_UNUSED(arguments)
@@ -439,6 +449,8 @@ bool QNVimPlugin::initialize()
     mCMDLine->setFont(TextEditor::TextEditorSettings::instance()->fontSettings().font());
 
     qobject_cast<QWidget *>(mCMDLine->parentWidget()->children()[2])->hide();
+
+    saveCursorFlashTime(QApplication::cursorFlashTime());
 
     auto action = new QAction(tr("Toggle QNVim"), this);
     Core::Command *cmd = Core::ActionManager::registerAction(action, Constants::TOGGLE_ID,
@@ -594,6 +606,9 @@ void QNVimPlugin::toggleQNVim()
     } else {
         qobject_cast<QWidget *>(mCMDLine->parentWidget()->children()[2])->show();
         mCMDLine->deleteLater();
+
+        disconnect(QApplication::styleHints(), &QStyleHints::cursorFlashTimeChanged, this, &QNVimPlugin::saveCursorFlashTime);
+        QApplication::setCursorFlashTime(mSavedCursorFlashTime);
 
         mNumbersColumn->deleteLater();
         connect(mNVim->api2()->nvim_command("q!"), &NeovimQt::MsgpackRequest::finished,

--- a/qnvimplugin.h
+++ b/qnvimplugin.h
@@ -105,6 +105,10 @@ protected:
 
     void triggerCommand(const QByteArray &);
 
+private slots:
+    // Save cursor flash time to variable instead of changing real value
+    void saveCursorFlashTime(int cursorFlashTime);
+
 private:
     void editorOpened(Core::IEditor *);
     void editorAboutToClose(Core::IEditor *);
@@ -155,6 +159,8 @@ private:
 
     int mSettingBufferFromVim = 0;
     unsigned long long mSyncCounter = 0;
+
+    int mSavedCursorFlashTime = -1;
 };
 
 class HelpEditorFactory : public TextEditor::PlainTextEditorFactory {


### PR DESCRIPTION
Closes #12. I think that this should be a default as in Neovim, Neovim Qt, FakeVim and others. There is can be an option to disable it, but I suggest to provide it in future with other useful options.
I added a private slot that saves [cursorFlashTime](https://doc.qt.io/qt-5/qapplication.html#cursorFlashTime-prop) to a variable (to restore it later) and sets application `cursorFlashTime` to zero. It also will listen for changes because the documentation says that this value can be changed by desktop settings. And I also restore the value after plugin toggling.
Please fell free to make a suggestions about naming or style.