### PR TITLE
Fix toggling

### DIFF
--- a/qnvimplugin.h
+++ b/qnvimplugin.h
@@ -85,7 +85,6 @@ public:
     ~QNVimPlugin();
 
     bool initialize(const QStringList &, QString *);
-    bool initialize();
     void extensionsInitialized();
     ShutdownFlag aboutToShutdown();
 
@@ -110,6 +109,7 @@ private slots:
     void saveCursorFlashTime(int cursorFlashTime);
 
 private:
+    void initialize(bool reopen);
     void editorOpened(Core::IEditor *);
     void editorAboutToClose(Core::IEditor *);
 


### PR DESCRIPTION
- Move "Toggle QNVim" initalization into `QNVimPlugin::initialize(const QStringList &arguments, QString *errorString)` to call it only once (no need to call it every toggle).
- Add `bool reopen` argument to `initialize()` to reapply initialization to current document for toggling, closes #21.
- Move `initialize()` to the private section and change return value from `bool` to `void` because this function always returned true and its value was not used in `toggleQNVim` in any way. Exactly the same approach is used in [FakeVim](https://github.com/qt-creator/qt-creator/blob/7b73d286fccaaa95edec312248bbc498e6d911b4/src/plugins/fakevim/fakevimplugin.cpp#L600), so I think it's ok.