### PR TITLE
Process completion in insert mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. This projec
 
 [Full Changelog](https://github.com/crow-translate/crow-translate/compare/2.3.1...HEAD)
 
+**Added**
+
+- Automatic completion on typing.
+
 **Changed**
 
 - Fix `number` not showing correctly when `relativenumber` was enabled.

--- a/qnvimplugin.cpp
+++ b/qnvimplugin.cpp
@@ -467,7 +467,7 @@ bool QNVimPlugin::eventFilter(QObject *object, QEvent *event)
 {
     if (!mEnabled)
         return false;
-    /* if (qobject_cast<QLabel *>(object)) */
+
     if (qobject_cast<TextEditor::TextEditorWidget *>(object) or qobject_cast<QPlainTextEdit *>(object)) {
         if (event->type() == QEvent::Resize) {
             QTimer::singleShot(100, [=]() { fixSize(); });
@@ -484,6 +484,11 @@ bool QNVimPlugin::eventFilter(QObject *object, QEvent *event)
 #endif
         QString key = mInputConv->convertKey(text, keyEvent->key(), modifiers);
         mNVim->api2()->nvim_input(mNVim->encode(key));
+
+        // Process text event in insert mode to show autocompletion
+        if (mMode.startsWith("i") and !text.isEmpty())
+            return false;
+
         return true;
     } else if (event->type() == QEvent::ShortcutOverride) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);

--- a/qnvimplugin.cpp
+++ b/qnvimplugin.cpp
@@ -483,7 +483,7 @@ bool QNVimPlugin::eventFilter(QObject *object, QEvent *event)
             text = modifiers & Qt::ShiftModifier ? QChar(keyEvent->key()) : QChar(keyEvent->key()).toLower();
 #endif
         // Process text event in insert mode to show autocompletion
-        if (mMode.startsWith("i") and !text.isEmpty() and modifiers == Qt::ShiftModifier)
+        if (mMode.startsWith("i") and !text.isEmpty() and (modifiers == Qt::ShiftModifier or modifiers == Qt::NoModifier))
             return false;
 
         QString key = mInputConv->convertKey(text, keyEvent->key(), modifiers);

--- a/qnvimplugin.cpp
+++ b/qnvimplugin.cpp
@@ -482,13 +482,12 @@ bool QNVimPlugin::eventFilter(QObject *object, QEvent *event)
         if (QChar(keyEvent->key()).isLetterOrNumber())
             text = modifiers & Qt::ShiftModifier ? QChar(keyEvent->key()) : QChar(keyEvent->key()).toLower();
 #endif
-        QString key = mInputConv->convertKey(text, keyEvent->key(), modifiers);
-        mNVim->api2()->nvim_input(mNVim->encode(key));
-
         // Process text event in insert mode to show autocompletion
-        if (mMode.startsWith("i") and !text.isEmpty())
+        if (mMode.startsWith("i") and !text.isEmpty() and modifiers == Qt::ShiftModifier)
             return false;
 
+        QString key = mInputConv->convertKey(text, keyEvent->key(), modifiers);
+        mNVim->api2()->nvim_input(mNVim->encode(key));
         return true;
     } else if (event->type() == QEvent::ShortcutOverride) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);


### PR DESCRIPTION
Closes #18. I disable event filtering for events in insert mode that contains text to enable auto-completion. I used `startsWith` because this can be applied for `ic` mode.