### PR TITLE
Process completion in insert mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. This projec
 
 [Full Changelog](https://github.com/crow-translate/crow-translate/compare/2.3.1...HEAD)
 
+**Added**
+
+- Automatic completion on typing.
+
 **Changed**
 
 - Fix `number` not showing correctly when `relativenumber` was enabled.

--- a/qnvimplugin.cpp
+++ b/qnvimplugin.cpp
@@ -469,7 +469,7 @@ bool QNVimPlugin::eventFilter(QObject *object, QEvent *event)
 {
     if (!mEnabled)
         return false;
-    /* if (qobject_cast<QLabel *>(object)) */
+
     if (qobject_cast<TextEditor::TextEditorWidget *>(object) or qobject_cast<QPlainTextEdit *>(object)) {
         if (event->type() == QEvent::Resize) {
             QTimer::singleShot(100, [=]() { fixSize(); });
@@ -484,6 +484,10 @@ bool QNVimPlugin::eventFilter(QObject *object, QEvent *event)
         if (QChar(keyEvent->key()).isLetterOrNumber())
             text = modifiers & Qt::ShiftModifier ? QChar(keyEvent->key()) : QChar(keyEvent->key()).toLower();
 #endif
+        // Process text event in insert mode to show autocompletion
+        if (mMode.startsWith('i'))
+            return false;
+
         QString key = NeovimQt::Input::convertKey(*keyEvent);
         mNVim->api2()->nvim_input(mNVim->encode(key));
         return true;


### PR DESCRIPTION
Continuation of #25. Closes #18. I disable event filtering for events for insert mode to allow auto-completion. This how it works in [vscode-neovim](https://github.com/asvetliakov/vscode-neovim). This allows to have first-class insert mode and all other Neovim modes. I think that this is a good idea since completion in IDE is very important thing :)