### PR TITLE
Create clang-format file and format the code

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,9 @@
+---
+BasedOnStyle: LLVM
+IndentWidth: 4
+ColumnLimit: 0
+---
+Language: Cpp
+
+Standard: c++17
+---

--- a/src/numbers_column.cpp
+++ b/src/numbers_column.cpp
@@ -49,34 +49,36 @@
 #include <texteditor/texteditor.h>
 #include <texteditor/texteditorsettings.h>
 
-#include <QScrollBar>
 #include <QPainter>
+#include <QScrollBar>
 
 namespace QNVim {
 namespace Internal {
 
-NumbersColumn::NumbersColumn()
-{
+NumbersColumn::NumbersColumn() {
     setAttribute(Qt::WA_TransparentForMouseEvents, true);
     connect(TextEditor::TextEditorSettings::instance(),
-        &TextEditor::TextEditorSettings::displaySettingsChanged,
-        this, &NumbersColumn::updateGeometry);
+            &TextEditor::TextEditorSettings::displaySettingsChanged,
+            this, &NumbersColumn::updateGeometry);
 }
 
 void NumbersColumn::setEditor(TextEditor::TextEditorWidget *editor) {
     if (editor == mEditor)
         return;
+
     if (mEditor) {
         mEditor->removeEventFilter(this);
         disconnect(mEditor, &QPlainTextEdit::cursorPositionChanged,
-                this, &NumbersColumn::updateGeometry);
+                   this, &NumbersColumn::updateGeometry);
         disconnect(mEditor->verticalScrollBar(), &QScrollBar::valueChanged,
-                this, &NumbersColumn::updateGeometry);
+                   this, &NumbersColumn::updateGeometry);
         disconnect(mEditor->document(), &QTextDocument::contentsChanged,
-                this, &NumbersColumn::updateGeometry);
+                   this, &NumbersColumn::updateGeometry);
     }
+
     mEditor = editor;
     setParent(mEditor);
+
     if (mEditor) {
         mEditor->installEventFilter(this);
         connect(mEditor, &QPlainTextEdit::cursorPositionChanged,
@@ -86,9 +88,9 @@ void NumbersColumn::setEditor(TextEditor::TextEditorWidget *editor) {
         connect(mEditor->document(), &QTextDocument::contentsChanged,
                 this, &NumbersColumn::updateGeometry);
         show();
-    }
-    else
+    } else
         hide();
+
     updateGeometry();
 }
 
@@ -100,8 +102,10 @@ void NumbersColumn::setNumber(bool number) {
 void NumbersColumn::paintEvent(QPaintEvent *event) {
     if (not mEditor)
         return;
+
     QTextCursor firstVisibleCursor = mEditor->cursorForPosition(QPoint(0, 0));
     QTextBlock firstVisibleBlock = firstVisibleCursor.block();
+
     if (firstVisibleCursor.positionInBlock() > 0) {
         firstVisibleBlock = firstVisibleBlock.next();
         firstVisibleCursor.setPosition(firstVisibleBlock.position());
@@ -110,8 +114,10 @@ void NumbersColumn::paintEvent(QPaintEvent *event) {
     QTextBlock block = mEditor->textCursor().block();
     bool forward = firstVisibleBlock.blockNumber() > block.blockNumber();
     int n = 0;
+
     while (block.isValid() and block != firstVisibleBlock) {
         block = forward ? block.next() : block.previous();
+
         if (block.isVisible())
             n += forward ? 1 : -1;
     }
@@ -121,15 +127,18 @@ void NumbersColumn::paintEvent(QPaintEvent *event) {
     const QColor fg = pal.color(QPalette::Dark);
     const QColor bg = pal.color(QPalette::Background);
     p.setPen(fg);
+
     QFontMetricsF fm(mEditor->textDocument()->fontSettings().font());
     qreal lineHeight = block.layout()->boundingRect().height();
     QRectF rect(0, mEditor->cursorRect(firstVisibleCursor).y(), width(), lineHeight);
     bool hideLineNumbers = mEditor->lineNumbersVisible();
+
     while (block.isValid()) {
         if (block.isVisible()) {
             if ((not mNumber or n != 0) and rect.intersects(event->rect())) {
                 const int line = qAbs(n);
                 const QString number = QString::number(line);
+
                 if (hideLineNumbers)
                     p.fillRect(rect, bg);
                 if (hideLineNumbers or line < 100)
@@ -150,12 +159,14 @@ void NumbersColumn::paintEvent(QPaintEvent *event) {
 bool NumbersColumn::eventFilter(QObject *, QEvent *event) {
     if (event->type() == QEvent::Resize or event->type() == QEvent::Move)
         updateGeometry();
+
     return false;
 }
 
 void NumbersColumn::updateGeometry() {
     if (not mEditor)
         return;
+
     QFontMetrics fm(mEditor->textDocument()->fontSettings().font());
     int lineHeight = fm.lineSpacing();
     setFont(mEditor->extraArea()->font());
@@ -164,10 +175,13 @@ void NumbersColumn::updateGeometry() {
     bool marksVisible = mEditor->marksVisible();
     bool lineNumbersVisible = mEditor->lineNumbersVisible();
     bool foldMarksVisible = mEditor->codeFoldingVisible();
+
     if (marksVisible and lineNumbersVisible)
         rect.setLeft(lineHeight);
+
     if (foldMarksVisible and (marksVisible or lineNumbersVisible))
         rect.setRight(rect.right() - (lineHeight + lineHeight % 2));
+
     setGeometry(rect);
 
     update();

--- a/src/numbers_column.h
+++ b/src/numbers_column.h
@@ -47,26 +47,25 @@
 #include <QWidget>
 
 namespace TextEditor {
-    class TextEditorWidget;
+class TextEditorWidget;
 }
 
 namespace QNVim {
 namespace Internal {
 
-class NumbersColumn : public QWidget
-{
+class NumbersColumn : public QWidget {
     Q_OBJECT
     bool mNumber = false;
     TextEditor::TextEditorWidget *mEditor = nullptr;
 
-public:
+  public:
     NumbersColumn();
 
     void setEditor(TextEditor::TextEditorWidget *);
     void setNumber(bool);
     void updateGeometry();
 
-protected:
+  protected:
     void paintEvent(QPaintEvent *event);
     bool eventFilter(QObject *, QEvent *);
 };

--- a/src/qnvimconstants.h
+++ b/src/qnvimconstants.h
@@ -6,5 +6,5 @@ namespace Constants {
 const char TOGGLE_ID[] = "QNVim.Toggle";
 const char MENU_ID[] = "QNVim.Menu";
 
-} // namespace QNVim
 } // namespace Constants
+} // namespace QNVim

--- a/src/qnvimplugin.h
+++ b/src/qnvimplugin.h
@@ -44,8 +44,8 @@
 
 #pragma once
 
-#include "qnvim_global.h"
 #include "numbers_column.h"
+#include "qnvim_global.h"
 
 #include <extensionsystem/iplugin.h>
 #include <texteditor/plaintexteditorfactory.h>
@@ -59,15 +59,15 @@ class QPlainTextEdit;
 QT_END_NAMESPACE
 
 namespace Core {
-    class IEditor;
+class IEditor;
 }
 
 namespace ProjectExplorer {
-    class Project;
+class Project;
 }
 
 namespace NeovimQt {
-    class NeovimConnector;
+class NeovimConnector;
 }
 
 namespace QNVim {
@@ -79,7 +79,7 @@ class QNVimPlugin : public ExtensionSystem::IPlugin {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID "org.qt-project.Qt.QtCreatorPlugin" FILE "QNVim.json")
 
-public:
+  public:
     QNVimPlugin();
     ~QNVimPlugin();
 
@@ -90,7 +90,7 @@ public:
     bool eventFilter(QObject *, QEvent *);
     void toggleQNVim();
 
-protected:
+  protected:
     QString filename(Core::IEditor * = nullptr) const;
 
     void fixSize(Core::IEditor * = nullptr);
@@ -103,11 +103,11 @@ protected:
 
     void triggerCommand(const QByteArray &);
 
-private slots:
+  private slots:
     // Save cursor flash time to variable instead of changing real value
     void saveCursorFlashTime(int cursorFlashTime);
 
-private:
+  private:
     void initialize(bool reopen);
     void editorOpened(Core::IEditor *);
     void editorAboutToClose(Core::IEditor *);
@@ -164,14 +164,14 @@ private:
 class HelpEditorFactory : public TextEditor::PlainTextEditorFactory {
     Q_OBJECT
 
-public:
+  public:
     explicit HelpEditorFactory();
 };
 
 class TerminalEditorFactory : public TextEditor::PlainTextEditorFactory {
     Q_OBJECT
 
-public:
+  public:
     explicit TerminalEditorFactory();
 };
 


### PR DESCRIPTION
A lot of IDEs and text editors (Qt Creator included) support `.clang-format` file and are able to format the code automatically according to it. This change introduces this file and formats the code according to it. This sets the standard for code formatting. Later it would be possible to add CI checks or/and pre-commit hooks, that check or format the code.

The formatting rules are mostly arbitrary, so they can be changed, if suggested. I do not mind any particular standard.