### PR TITLE
refactor: fix some clazy and clang-tidy warnings

### DIFF
--- a/src/numbers_column.cpp
+++ b/src/numbers_column.cpp
@@ -83,11 +83,10 @@ void NumbersColumn::paintEvent(QPaintEvent *event) {
 
     QPainter p(this);
     QPalette pal = mEditor->extraArea()->palette();
-    const QColor fg = pal.color(QPalette::Dark);
-    const QColor bg = pal.color(QPalette::Background);
+    const QColor fg = pal.color(QPalette::WindowText);
+    const QColor bg = pal.color(QPalette::Window);
     p.setPen(fg);
 
-    QFontMetricsF fm(mEditor->textDocument()->fontSettings().font());
     qreal lineHeight = block.layout()->boundingRect().height();
     QRectF rect(0, mEditor->cursorRect(firstVisibleCursor).y(), width(), lineHeight);
     bool hideLineNumbers = mEditor->lineNumbersVisible();

--- a/src/qnvimplugin.cpp
+++ b/src/qnvimplugin.cpp
@@ -362,7 +362,6 @@ void QNVimPlugin::syncFromVim() {
                 for (const auto &d : diff) {
                     switch (d.command) {
                     case Utils::Diff::Insert: {
-                        qWarning() << 3 << d.text << d.text.size() << d.text.length();
                         // Adjust cursor position if we do work in front of the cursor.
                         if (charactersInfrontOfCursor > 0) {
                             const int size = d.text.size();
@@ -375,7 +374,6 @@ void QNVimPlugin::syncFromVim() {
 
                     case Utils::Diff::Delete: {
                         // Adjust cursor position if we do work in front of the cursor.
-                        qWarning() << 2 << d.text << d.text.size() << d.text.length();
                         if (charactersInfrontOfCursor > 0) {
                             const int size = d.text.size();
                             charactersInfrontOfCursor -= size;
@@ -391,7 +389,6 @@ void QNVimPlugin::syncFromVim() {
 
                     case Utils::Diff::Equal:
                         // Adjust cursor position
-                        qWarning() << 1 << d.text << d.text.size() << d.text.length();
                         charactersInfrontOfCursor -= d.text.size();
                         cursor.setPosition(cursor.position() + d.text.length(), QTextCursor::MoveAnchor);
                         break;


### PR DESCRIPTION
When you open the project in Qt Creator, it gives you some warnings using clang-tidy and clazy static analysis tools.

This change fixes most of them. 

Also, color deprecation warning was fixed.