### PR TITLE
feat: update to qt creator 7

### DIFF
--- a/external/qtcreator/version.cmake
+++ b/external/qtcreator/version.cmake
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: None
 # SPDX-License-Identifier: MIT
 
-set(QT_CREATOR_VERSION "6.0.2")
+set(QT_CREATOR_VERSION "7.0.2")
 set(QT_CREATOR_SNAPSHOT "")

--- a/src/QNVim.json.in
+++ b/src/QNVim.json.in
@@ -1,6 +1,6 @@
 {
     \"Name\" : \"QNVim\",
-    \"Version\" : \"6.0.2_1\",
+    \"Version\" : \"7.0.2_1\",
     \"Vendor\" : \"Sassan Haradji\",
     \"Copyright\" : \"(C) Sassan Haradji\",
     \"License\" : \"MIT\",

--- a/src/qnvimplugin.cpp
+++ b/src/qnvimplugin.cpp
@@ -897,11 +897,11 @@ void QNVimPlugin::handleNotification(const QByteArray &name, const QVariantList 
                                                    << "h"
                                                    << "pro")
                                         .contains(fileInfo.suffix(), Qt::CaseInsensitive))
-                                    e = Core::EditorManager::openEditor(filename);
+                                    e = Core::EditorManager::openEditor(Utils::FilePath::fromString(filename));
                                 else
-                                    e = Core::EditorManager::openEditor(filename, "Core.PlainTextEditor");
+                                    e = Core::EditorManager::openEditor(Utils::FilePath::fromString(filename), "Core.PlainTextEditor");
                             } else {
-                                e = Core::EditorManager::openEditor(filename);
+                                e = Core::EditorManager::openEditor(Utils::FilePath::fromString(filename));
                             }
                         } else {
                             qDebug(Main) << 123;


### PR DESCRIPTION
Test plan:
1. Run Qt Creator 7 with the plugin (build and run with Qt Creator run configuration: `%{sourceDir}\external\qtcreator\dist-Windows-7.0.2\bin\qtcreator.exe` `-pluginpath %{buildDir}\lib\qtcreator\plugins`).
2. Neovim should attach, editing should generally work.