### PR TITLE
feat: update to qt creator 8

### DIFF
--- a/external/qtcreator/version.cmake
+++ b/external/qtcreator/version.cmake
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: None
 # SPDX-License-Identifier: MIT
 
-set(QT_CREATOR_VERSION "7.0.2")
+set(QT_CREATOR_VERSION "8.0.2")
 set(QT_CREATOR_SNAPSHOT "")

--- a/src/QNVim.json.in
+++ b/src/QNVim.json.in
@@ -1,6 +1,6 @@
 {
     \"Name\" : \"QNVim\",
-    \"Version\" : \"7.0.2_1\",
+    \"Version\" : \"8.0.2_1\",
     \"Vendor\" : \"Sassan Haradji\",
     \"Copyright\" : \"(C) Sassan Haradji\",
     \"License\" : \"MIT\",


### PR DESCRIPTION
No API changes, that affect us. 

Test Plan:

1. Run Qt Creator 8 with the plugin (build and run with Qt Creator run configuration: `%{sourceDir}\external\qtcreator\dist-Windows-8.0.2\bin\qtcreator.exe` `-pluginpath %{buildDir}\lib\qtcreator\plugins`).
2. Neovim should attach, editing should generally work.