### PR TITLE
feat: update to qt creator 9

### DIFF
--- a/external/qtcreator/version.cmake
+++ b/external/qtcreator/version.cmake
@@ -1,5 +1,5 @@
 # SPDX-FileCopyrightText: None
 # SPDX-License-Identifier: MIT
 
-set(QT_CREATOR_VERSION "8.0.2")
+set(QT_CREATOR_VERSION "9.0.1")
 set(QT_CREATOR_SNAPSHOT "")

--- a/src/QNVim.json.in
+++ b/src/QNVim.json.in
@@ -1,6 +1,6 @@
 {
     \"Name\" : \"QNVim\",
-    \"Version\" : \"8.0.2_1\",
+    \"Version\" : \"9.0.2_1\",
     \"Vendor\" : \"Sassan Haradji\",
     \"Copyright\" : \"(C) Sassan Haradji\",
     \"License\" : \"MIT\",

--- a/src/qnvimplugin.cpp
+++ b/src/qnvimplugin.cpp
@@ -672,7 +672,7 @@ autocmd VimEnter * let $MYQVIMRC=substitute($MYVIMRC, 'init.vim$', 'qnvim.vim', 
         options.insert("ext_hlstate", true);
         options.insert("rgb", true);
         NeovimQt::MsgpackRequest *request = mNVim->api2()->nvim_ui_attach(mWidth, mHeight, options);
-        request->setTimeout(2000);
+        request->setTimeout(10000);
         connect(request, &NeovimQt::MsgpackRequest::timeout, mNVim, &NeovimQt::NeovimConnector::fatalTimeout);
         connect(request, &NeovimQt::MsgpackRequest::timeout, [=]() {
             qCritical(Main) << "Neovim: Connection timed out!";


### PR DESCRIPTION
No API changes, that affect us. 

Test Plan:

1. Run Qt Creator 9 with the plugin (build and run with Qt Creator run configuration: `%{sourceDir}\external\qtcreator\dist-Windows-9.0.1\bin\qtcreator.exe` `-pluginpath %{buildDir}\lib\qtcreator\plugins`).
2. Neovim should attach, editing should generally work.

With this change, you can finally install the plugin on modern Qt Creator.